### PR TITLE
✨ Content Type Limitation & Saving Request WAV File to Local Storage

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Reason for Work
+
+
+<br/>
+
+## Tasks
+
+
+
+<br/>
+
+## Issues
+

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 *.py[cod]
 *$py.class
 .pytest_cache/
+
+/debug_audio

--- a/app/api/routes/routes.py
+++ b/app/api/routes/routes.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, HTTPException, Request
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request, Header
 
 from app.api.dto.correct_dto import CorrectionResponse, ErrorResponse
 from app.common.aop.ApiLogRouter import ApiLogRouter
@@ -11,8 +13,19 @@ router = APIRouter(route_class=ApiLogRouter)
 
 
 @router.post("/correct", response_model=CorrectionResponse, responses={500: {"model": ErrorResponse}})
-async def correct_english_text(request: Request):
+async def correct_english_text(
+        request: Request,
+        content_type: Optional[str] = Header(None)
+):
+    allowed_content_types = ["application/octet-stream", "audio/wav"]
+    if content_type not in allowed_content_types:
+        raise HTTPException(
+            status_code=415,
+            detail=f"Unsupported media type. Only {', '.join(allowed_content_types)} are supported."
+        )
+
     audio_data = await request.body()
+    logger.info(f"Received audio data size: {len(audio_data)} bytes")
 
     try:
         # 1. 텍스트 교정

--- a/app/common/utils/wav_util.py
+++ b/app/common/utils/wav_util.py
@@ -1,0 +1,68 @@
+import io
+from typing import Dict, Any, Optional, Tuple
+
+import numpy as np
+import scipy.io.wavfile as wavfile
+
+from app.common.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def diagnose_wav_bytes(byte_data: bytes) -> Dict[str, Any]:
+    """WAV 바이트 데이터를 분석하여 헤더 정보 추출"""
+    if len(byte_data) < 44:  # WAV 헤더는 최소 44바이트
+        return {"error": "Data too short for WAV header"}
+
+    try:
+        result = {}
+
+        # 'RIFF' 체크
+        if byte_data[0:4] != b'RIFF':
+            return {"error": f"Invalid RIFF header: {byte_data[0:4]}"}
+
+        result["chunk_size"] = int.from_bytes(byte_data[4:8], byteorder='little')
+
+        # 'WAVE' 체크
+        if byte_data[8:12] != b'WAVE':
+            return {"error": f"Invalid WAVE marker: {byte_data[8:12]}"}
+
+        # 'fmt ' 체크
+        if byte_data[12:16] != b'fmt ':
+            return {"error": f"Invalid fmt marker: {byte_data[12:16]}"}
+
+        result["subchunk1_size"] = int.from_bytes(byte_data[16:20], byteorder='little')
+        result["audio_format"] = int.from_bytes(byte_data[20:22], byteorder='little')
+        result["num_channels"] = int.from_bytes(byte_data[22:24], byteorder='little')
+        result["sample_rate"] = int.from_bytes(byte_data[24:28], byteorder='little')
+        result["byte_rate"] = int.from_bytes(byte_data[28:32], byteorder='little')
+        result["block_align"] = int.from_bytes(byte_data[32:34], byteorder='little')
+        result["bits_per_sample"] = int.from_bytes(byte_data[34:36], byteorder='little')
+
+        # 'data' 체크
+        if byte_data[36:40] != b'data':
+            return {"error": f"Invalid data marker: {byte_data[36:40]}"}
+
+        result["subchunk2_size"] = int.from_bytes(byte_data[40:44], byteorder='little')
+        result["data_size"] = len(byte_data) - 44
+
+        return result
+    except Exception as e:
+        return {"error": f"Error analyzing WAV header: {str(e)}"}
+
+
+def extract_wav_info(byte_data: bytes) -> Tuple[Optional[int], Optional[np.ndarray]]:
+    """바이트 데이터에서 WAV 정보 추출 시도"""
+    try:
+        with io.BytesIO(byte_data) as wav_buffer:
+            sampling_rate, data = wavfile.read(wav_buffer)
+            return sampling_rate, data
+    except Exception as e:
+        logger.error(f"Error extracting WAV info: {str(e)}")
+        return None, None
+
+
+def is_valid_wav(byte_data: bytes) -> bool:
+    """WAV 형식이 유효한지 확인합니다."""
+    header_info = diagnose_wav_bytes(byte_data)
+    return "error" not in header_info

--- a/app/domain/services/correct_text_helper.py
+++ b/app/domain/services/correct_text_helper.py
@@ -6,6 +6,8 @@ from app.common.utils.logger import get_logger
 from app.domain.services.pattern_matching import validate_correction
 from app.infrastructure.clients.llm.alibaba.qwen_client import QwenTurboClient
 from app.infrastructure.clients.llm.llm_client import LlmClient
+from app.infrastructure.clients.storage.audio_storage_client import AudioStorageClient
+from app.infrastructure.clients.storage.local.local_audio_storage_client import LocalAudioStorageClient
 from app.infrastructure.clients.stt.naver.naver_stt_client import NaverClovaSpeechRecognizer
 from app.infrastructure.clients.stt.speech_recognizer import SpeechRecognizer
 
@@ -27,8 +29,12 @@ class CorrectionResult(BaseModel):
 async def process_correction_request(
         command: CorrectionCommand,
         speech_recognizer: SpeechRecognizer = NaverClovaSpeechRecognizer(),
-        llm_client: LlmClient = QwenTurboClient()
+        llm_client: LlmClient = QwenTurboClient(),
+        audio_storage_client: AudioStorageClient = LocalAudioStorageClient()
 ):
+    saved_url = await audio_storage_client.save_audio(command.original, "wav")
+    logger.info(f"저장된 오디오 파일 경로: {saved_url}")
+
     try:
         # 1. STT 결과 추출
         text = await speech_recognizer.recognize(audio_data=command.original)

--- a/app/infrastructure/clients/storage/audio_storage_client.py
+++ b/app/infrastructure/clients/storage/audio_storage_client.py
@@ -1,0 +1,18 @@
+from typing import Protocol
+
+
+class AudioStorageClient(Protocol):
+    """오디오 저장 클라이언트 인터페이스"""
+
+    async def save_audio(self, audio_data: bytes, extension: str) -> str:
+        """
+        오디오 데이터를 저장
+
+        Args:
+            audio_data (bytes): 바이너리 오디오 데이터
+            extension (str): 파일 확장자
+
+        Returns:
+            str: 저장된 파일 경로
+        """
+        ...

--- a/app/infrastructure/clients/storage/local/local_audio_storage_client.py
+++ b/app/infrastructure/clients/storage/local/local_audio_storage_client.py
@@ -1,0 +1,64 @@
+import os
+from datetime import datetime
+
+import scipy.io.wavfile as wavfile
+
+from app.common.utils.logger import get_logger
+from app.common.utils.wav_util import diagnose_wav_bytes, extract_wav_info
+from app.infrastructure.clients.storage.audio_storage_client import AudioStorageClient
+
+logger = get_logger(__name__)
+
+
+class LocalAudioStorageClient(AudioStorageClient):
+    """로컬 파일 시스템을 이용한 오디오 저장"""
+
+    async def save_audio(self, audio_data: bytes, extension: str) -> str:
+        """
+        WAV 데이터를 파일로 저장합니다.
+        현재는 WAV 파일만 지원합니다.
+        """
+        if extension != "wav":
+            logger.warning(f"Unsupported audio extension: {extension}")
+            return ""
+
+        file_path = self._create_storage_dir()
+
+        # WAV 헤더 진단
+        header_info = diagnose_wav_bytes(audio_data)
+        if "error" in header_info:
+            logger.warning(f"WAV header diagnosis failed: {header_info['error']}")
+        else:
+            logger.info(f"WAV header info: {header_info}")
+
+        saved_path = None
+        # 방법 1: scipy로 처리 시도
+        try:
+            sampling_rate, data = extract_wav_info(audio_data)
+            if sampling_rate is not None and data is not None:
+                wavfile.write(file_path, sampling_rate, data)
+                logger.info(f"Successfully saved WAV using scipy: {sampling_rate}Hz, {data.shape} samples")
+                saved_path = file_path
+        except Exception as e:
+            logger.warning(f"Failed to process with scipy: {str(e)}")
+
+        # 방법 1이 실패하면 방법 2: 직접 바이트 저장
+        if saved_path is None:
+            try:
+                with open(file_path, 'wb') as file:
+                    file.write(audio_data)
+                logger.info(f"Saved raw bytes to {file_path}, size: {len(audio_data)} bytes")
+                saved_path = file_path
+            except Exception as e:
+                logger.error(f"Failed to save raw bytes: {str(e)}")
+                return ""
+
+        return saved_path
+
+    @staticmethod
+    def _create_storage_dir() -> str:
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        debug_dir = "debug_audio"
+        os.makedirs(debug_dir, exist_ok=True)
+
+        return os.path.join(debug_dir, f"audio_{timestamp}.wav")


### PR DESCRIPTION
## Reason for Work
- Content Type Limitation
- Saving Request WAV File to Local Storage

<br/>

## Tasks
![image](https://github.com/user-attachments/assets/02526f57-9c06-48e2-a487-d1c9bb4cfc64)

At first, I thought the CLOVA request issue was on my end, but it turned out to be a client-side issue.  
During this process, I realized the importance of saving the WAV file received from the client.  

Since I only accept WAV files, I implemented a filter to check the content type header.

<br/>

## Issues
- I need to implement a global exception handler.
